### PR TITLE
Update GeneralHelper.cs

### DIFF
--- a/Helper/GeneralHelper.cs
+++ b/Helper/GeneralHelper.cs
@@ -50,7 +50,7 @@ namespace VulnerableApp4Kubernetes.Helper
         {
             try
             {
-                FileStream fileStream = new FileStream(filename, FileMode.Open);
+                FileStream fileStream = new FileStream(filename, FileMode.Open, FileAccess.Read);
                 using (StreamReader reader = new StreamReader(fileStream))
                 {
                     string line = reader.ReadToEnd();


### PR DESCRIPTION
I was playing around with this app and noticed that when trying to access the file /run/secrets/kubernetes.io/serviceaccount/token I get an access denied error, since the file is loaded using a RO filesystem, and in the code it is not specified specifically that we want RO permissions. Adding the FileAccess.Read permission fixed that issue for me :)